### PR TITLE
位置の指定をワールド座標からグローバル座標に変更

### DIFF
--- a/src/Assets/Scripts/PuyoController.cs
+++ b/src/Assets/Scripts/PuyoController.cs
@@ -48,7 +48,7 @@ public class PuyoController : MonoBehaviour
 
     public void SetPos(Vector3 pos)
     {
-        this.transform.position = pos;
+        this.transform.localPosition = pos;
     }
 }
 


### PR DESCRIPTION
position での位置の指定はワールド座標での指定になります。
今回は、ボードからの相対座標で位置を指定したいので、ローカル座標で位置を指定していきます。
（これによって、Boardオブジェクトの位置を動かすだけで、全体的にずらすことができます。）